### PR TITLE
Including rules in Mark-Down format in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # Rules for /r/Linux
 
-Please help us create new and improved rules for the Linux subreddit.
+Please help us create new and improved rules for the [Linux subreddit](https://linux.reddit.com/).
 
 To contribute, create a pull request.  Rule suggestions/changes/etc. will be voted on in a post within the subreddit.
+
+# Rules Index
+* [Submission Rules](#submission_rules)
+* [Comment Rules](#comment_rules)
+
+## Submission Rules
+<a name="submission_rules"></a>
+### All submissions must NOT be:
+* Questions / requests for support.
+* NSFW.
+* Memes.
+* Links to sites that require logins or have a paywall.
+    
+### All submissions MUST be:
+
+* The original article - no link shorteners OR spamblogs, please!
+* Compliant with the site-wide reddit rules.
+
+## Comment Rules
+<a name="comment_rules"></a>
+### All comments MUST be:
+* Compliant with the site-wide reddit rules.


### PR DESCRIPTION
Hi @kruug, 

This PR moves the current rules to README.md (as [my previous comment](https://github.com/LinuxSubreddit/LinuxSubredditRules/pull/3#issuecomment-375077485)). 

I've included some anchors and a Rule Index so browsing them is easier when as the list grows. 

Regards!
